### PR TITLE
Appveyor jobs were expanded for multiple Scala and Java versions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,10 @@ environment:
   matrix:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
     - JAVA_HOME: C:\Program Files\Java\jdk10
+    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+      SCALA_VERSION: 2.13.0-M4
+    - JAVA_HOME: C:\Program Files\Java\jdk10
+      SCALA_VERSION: 2.13.0-M4
 
 install:
   - cmd: echo Using JDK at %JAVA_HOME%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,12 +5,14 @@ version: '{build}'
 image: Visual Studio 2015
 
 environment:
-  global:
-    JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-    SCALA_VERSION: 2.12.6
-    SBT_VERSION: 1.1.4
+  SCALA_VERSION: 2.12.6
+  SBT_VERSION: 1.1.4
+  matrix:
+    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+    - JAVA_HOME: C:\Program Files\Java\jdk10
 
 install:
+  - cmd: echo Using JDK at: %JAVA_HOME%
   - cmd: choco install sbt --version %SBT_VERSION% -ia "INSTALLDIR=""C:\sbt"""
   - cmd: SET PATH=C:\sbt\bin;%JAVA_HOME%\bin;%PATH%
   - cmd: SET SBT_OPTS=-Xmx4g

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
     - JAVA_HOME: C:\Program Files\Java\jdk10
 
 install:
-  - cmd: echo Using JDK at: %JAVA_HOME%
+  - cmd: echo Using JDK at %JAVA_HOME%
   - cmd: choco install sbt --version %SBT_VERSION% -ia "INSTALLDIR=""C:\sbt"""
   - cmd: SET PATH=C:\sbt\bin;%JAVA_HOME%\bin;%PATH%
   - cmd: SET SBT_OPTS=-Xmx4g


### PR DESCRIPTION
We add 3 new jobs for AppVeyor, testing JDK 10 and Scala 2.13.0-M4 for the tests as well.